### PR TITLE
Microsoft Clarity を導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@microsoft/clarity": "^1.0.2",
         "@next/third-parties": "^16.1.6",
         "clsx": "^2.1.1",
         "microcms-js-sdk": "^3.2.0",
@@ -1504,6 +1505,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
+      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@microsoft/clarity": "^1.0.2",
     "@next/third-parties": "^16.1.6",
     "clsx": "^2.1.1",
     "microcms-js-sdk": "^3.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { JetBrains_Mono, Noto_Sans_JP, Press_Start_2P } from 'next/font/google';
 
+import { ClarityInit } from '@/components/layout/clarity';
 import { Footer } from '@/components/layout/footer';
 import { Header } from '@/components/layout/header';
 import { generateMetadata as genMeta } from '@/lib/seo/metadata';
@@ -58,6 +59,11 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         {/* Google Analytics 4（環境変数未設定時はスキップ） */}
         {process.env.NEXT_PUBLIC_GA4_ID && (
           <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA4_ID} />
+        )}
+
+        {/* Microsoft Clarity（環境変数未設定時はスキップ） */}
+        {process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID && (
+          <ClarityInit projectId={process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID} />
         )}
       </body>
     </html>

--- a/src/components/layout/clarity/index.tsx
+++ b/src/components/layout/clarity/index.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import Clarity from '@microsoft/clarity';
+
+/** Clarity 初期化コンポーネントの Props */
+type ClarityInitProps = {
+  /** Microsoft Clarity のプロジェクトID */
+  projectId: string;
+};
+
+/**
+ * Microsoft Clarity 初期化コンポーネント
+ * マウント時に一度だけ Clarity のトラッキングを開始する
+ */
+export function ClarityInit({ projectId }: ClarityInitProps) {
+  useEffect(() => {
+    Clarity.init(projectId);
+  }, [projectId]);
+
+  return null;
+}


### PR DESCRIPTION
## 変更概要
Microsoft Clarity を導入しました(#22)。

- `@microsoft/clarity` パッケージを追加
- Clarity 初期化用クライアントコンポーネント `src/components/layout/clarity/index.tsx` を新規作成
- `layout.tsx` に組み込み。環境変数 `NEXT_PUBLIC_CLARITY_PROJECT_ID` 未設定時はレンダリングをスキップ

## テスト確認事項
- [x] `npm run build` 成功
- [x] ESLint エラーなし
- [x] 環境変数未設定時に Clarity がスキップされることを確認(ローカルビルド)
- [ ] マージ後、Vercel 本番環境で Clarity ダッシュボードにデータが届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)